### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gem](https://img.shields.io/gem/v/clintegracon.svg?style=flat)](http://rubygems.org/gems/clintegracon)
 [![Build Status](https://img.shields.io/travis/mrackwitz/CLIntegracon/master.svg?style=flat)](https://travis-ci.org/mrackwitz/CLIntegracon)
 [![Code Climate](https://img.shields.io/codeclimate/github/mrackwitz/CLIntegracon.svg?style=flat)](https://codeclimate.com/github/mrackwitz/CLIntegracon)
+[![Inline docs](http://inch-ci.org/github/mrackwitz/CLIntegracon.svg?branch=master&style=flat)](http://inch-ci.org/github/mrackwitz/CLIntegracon)
 [![Dependency Status](http://img.shields.io/gemnasium/mrackwitz/CLIntegracon.svg?style=flat)](https://gemnasium.com/mrackwitz/CLIntegracon)
 
 CLIntegracon allows you to build *Integration* specs for your *CLI*,


### PR DESCRIPTION
Hi there,

this adds the docs badge you requested [here](https://github.com/rrrene/inch-pages/pull/92/files).

Please note it is not delivered via the old Inch Pages project, but the successor [http://inch-ci.org](Inch CI), which gives more control to project maintainers (refresh mechanism, web-hooks, suggestions).
