### PR TITLE
Fix: empty diffs for 'execution_output.txt'

### DIFF
--- a/spec/bacon/execution_output.txt
+++ b/spec/bacon/execution_output.txt
@@ -4,7 +4,7 @@ CLIntegracon::Adapter::Bacon
       without milk
         - $ coffee-maker --no-milk
         - BlackEye.brewed-coffee
-        - CaPheSuaDa.brewed-coffee
+        - CaPheSuaDa.brewed-coffee [FAILED]
         - Coffeemakerfile.yml
         - RedTux.brewed-coffee
         - execution_output.txt
@@ -22,11 +22,23 @@ CLIntegracon::Adapter::Bacon
       - execution_output.txt
       - should not produce unexpected files
 
+Bacon::Error: File comparison error `CaPheSuaDa.brewed-coffee` for coffeemaker_no_milk:
+--- DIFF -----------------------------------------------------------------------
+ class CaPheSuaDa < BrewedCoffee
+[31m-  @origin = "Việt Nam"[0m
+--- END ------------------------------------------------------------------------
+
+	spec/bacon/spec_helper.rb:44
+	spec/bacon/spec_helper.rb:43
+	spec/bacon/spec_helper.rb:41
+	spec/bacon/spec_helper.rb:17
+	spec/bacon/spec_helper.rb:15
+
 Bacon::Error: Unexpected files for coffeemaker_no_milk:
   * [32mAffogato.brewed-coffee[0m
-	spec/bacon/spec_helper.rb:40
-	spec/bacon/spec_helper.rb:39
-	spec/bacon/spec_helper.rb:37
+	spec/bacon/spec_helper.rb:44
+	spec/bacon/spec_helper.rb:43
+	spec/bacon/spec_helper.rb:41
 	spec/bacon/spec_helper.rb:17
 	spec/bacon/spec_helper.rb:15
 
@@ -37,17 +49,17 @@ Bacon::Error: File comparison error `Affogato.brewed-coffee` for coffeemaker_swe
    @sweetner = honey
 --- END ------------------------------------------------------------------------
 
-	spec/bacon/spec_helper.rb:44
-	spec/bacon/spec_helper.rb:43
-	spec/bacon/spec_helper.rb:37
+	spec/bacon/spec_helper.rb:48
+	spec/bacon/spec_helper.rb:47
+	spec/bacon/spec_helper.rb:41
 	spec/bacon/spec_helper.rb:17
 	spec/bacon/spec_helper.rb:15
 
 Bacon::Error: Missing file for coffeemaker_sweetner_honey:
   * [31mBlackEye.brewed-coffee[0m
-	spec/bacon/spec_helper.rb:44
-	spec/bacon/spec_helper.rb:43
-	spec/bacon/spec_helper.rb:37
+	spec/bacon/spec_helper.rb:48
+	spec/bacon/spec_helper.rb:47
+	spec/bacon/spec_helper.rb:41
 	spec/bacon/spec_helper.rb:17
 	spec/bacon/spec_helper.rb:15
 
@@ -59,10 +71,10 @@ Bacon::Error: File comparison error `RedTux.brewed-coffee` for coffeemaker_sweet
 [32m+  @sweetner = honey[0m
 --- END ------------------------------------------------------------------------
 
-	spec/bacon/spec_helper.rb:44
-	spec/bacon/spec_helper.rb:43
-	spec/bacon/spec_helper.rb:37
+	spec/bacon/spec_helper.rb:48
+	spec/bacon/spec_helper.rb:47
+	spec/bacon/spec_helper.rb:41
 	spec/bacon/spec_helper.rb:17
 	spec/bacon/spec_helper.rb:15
 
-17 specifications (27 requirements), 4 failures, 0 errors
+17 specifications (27 requirements), 5 failures, 0 errors

--- a/spec/bacon/spec_helper.rb
+++ b/spec/bacon/spec_helper.rb
@@ -32,6 +32,10 @@ describe CLIntegracon::Adapter::Bacon do
     file_tree_spec_context do |c|
       c.ignores '.DS_Store'
       c.ignores '.gitkeep'
+
+      c.has_special_handling_for 'CaPheSuaDa.brewed-coffee' do |path|
+        File.read(path)
+      end
     end
 
     describe 'Brew recipes' do

--- a/spec/integration/coffeemaker_no_milk/after/CaPheSuaDa.brewed-coffee
+++ b/spec/integration/coffeemaker_no_milk/after/CaPheSuaDa.brewed-coffee
@@ -1,1 +1,2 @@
 class CaPheSuaDa < BrewedCoffee
+  @origin = "Việt Nam"


### PR DESCRIPTION
This fixes empty diffs for preprocessed files by setting the option `source` for the third parameter when initializing `Diffy::Diff`.

If the `FileTreeSpecContext` is configured with `has_special_handling_for` for an expected file, and this method, doesn't return a `Pathname` but instead a `String` then the strings have not been properly compared. This caused that an empty but erroneous diff was shown.
