### PR TITLE
[Formatter] Show carriage returns in the file diff

### DIFF
--- a/lib/CLIntegracon/formatter.rb
+++ b/lib/CLIntegracon/formatter.rb
@@ -151,7 +151,7 @@ module CLIntegracon
           when /^\+/ then line.green
           when /^-/ then  line.red
           else            line
-        end.gsub("\n",'')
+        end.gsub("\n",'').gsub("\r", '\r')
       end
       description << "--- END ".ljust(max_width, '-')
       description << ''

--- a/spec/unit/formatter_spec.rb
+++ b/spec/unit/formatter_spec.rb
@@ -65,6 +65,20 @@ $after
 --- END ------------
 EOS
       end
+
+      it 'should show carriage returns' do
+        diff = ['$before', "+ $blah\radd", "- $blah\rremoved", '$after']
+        diff.stubs(:relative_path => '$relative_path')
+        @formatter.describe_file_diff(diff, 20).to_s.should.be.eql? <<-EOS
+File comparison error `$relative_path` for $spec_folder:
+--- DIFF -----------
+$before
+\e[32m+ $blah\\radd\e[0m
+\e[31m- $blah\\rremoved\e[0m
+$after
+--- END ------------
+EOS
+      end
     end
   end
 


### PR DESCRIPTION
@mrackwitz this should make debugging the spurious CocoaPods failures easier